### PR TITLE
add env_grep TRAVIS to before_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ before_script:
       && $CMAKE/bin/cmake .
       ;
     fi
+    ;
+    env | grep ^TRAVIS
+    ;
 
 script:
   - make


### PR DESCRIPTION
added a `env | grep ^TRAVIS` to `before_script:` to be able to catch TRAVIS_<*> variables on the build
